### PR TITLE
docs: README.md整理とdocs/overview.md作成 (#9, #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 .venv/
 .hypothesis/
 .claude/scheduled_tasks.lock
+.pr-creation-authorized

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "MD013": {
+      "line_length": 200,
+      "code_blocks": false,
+      "tables": false
+    },
+    "MD024": false,
+    "MD029": false,
+    "MD036": false,
+    "MD040": false,
+    "MD041": false,
+    "MD060": false
+  },
+  "globs": [
+    "docs/**/*.md",
+    "*.md"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,4 @@
 
 ## プロジェクト基盤情報
 
-@README.md
-
-## Git 運用
-
-main ブランチのみで運用する。develop ブランチは使用しない。
-
-- 作業ブランチ: `feature/{機能名}-#{Issue番号}` / `bugfix/{修正内容}-#{Issue番号}` を main から作成
-- PR の base: `main`
-- 直接 push は不可、全ての変更は PR 経由で行う
+@docs/overview.md

--- a/README.md
+++ b/README.md
@@ -2,18 +2,7 @@
 
 複数プロジェクトで共有する Python ライブラリ。制約付き HTTP クライアントやシークレットストアなどの共通ユーティリティを提供する。
 
-## パッケージ構造
-
-| パッケージ | 概要 |
-|-----------|------|
-| `py_common_lib.core` | HTTP 非依存のコアコンポーネント（BudgetTracker, CircuitBreaker） |
-| `py_common_lib.httpx` | httpx 用の制約付き HTTP クライアント（ConstrainedClient）とクランプユーティリティ |
-| `py_common_lib.secrets` | OS セキュアストレージからのシークレット取得（keyring） |
-
-## 動作環境
-
-- Python 3.11+
-- パッケージ管理: uv
+詳細は [docs/overview.md](docs/overview.md) を参照。
 
 ## セットアップ
 
@@ -29,7 +18,3 @@ uv run ruff check .
 uv run ruff format --check .
 uv run mypy src
 ```
-
-## Git 運用
-
-main ブランチのみで運用する。直接 push は不可、全ての変更は PR 経由で行う。

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ## パッケージ構造
 
 | パッケージ | 概要 |
-| ----------- | ------ |
+|-----------|------|
 | `py_common_lib.core` | HTTP 非依存のコアコンポーネント（BudgetTracker, CircuitBreaker） |
-| `py_common_lib.httpx` | httpx 用の制約付き HTTP クライアントとクランプユーティリティ |
+| `py_common_lib.httpx` | httpx 用の制約付き HTTP クライアント（ConstrainedClient）とクランプユーティリティ |
 | `py_common_lib.secrets` | OS セキュアストレージからのシークレット取得（keyring） |
 
 ## 動作環境

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,9 +5,9 @@
 ## パッケージ構造
 
 | パッケージ | 概要 |
-| ----------- | ------ |
+|-----------|------|
 | `py_common_lib.core` | HTTP 非依存のコアコンポーネント（BudgetTracker, CircuitBreaker） |
-| `py_common_lib.httpx` | httpx 用の制約付き HTTP クライアントとクランプユーティリティ |
+| `py_common_lib.httpx` | httpx 用の制約付き HTTP クライアント（ConstrainedClient）とクランプユーティリティ |
 | `py_common_lib.secrets` | OS セキュアストレージからのシークレット取得（keyring） |
 
 ## 動作環境

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,12 +15,6 @@
 - Python 3.11+
 - パッケージ管理: uv
 
-## セットアップ
-
-```bash
-uv sync
-```
-
 ## テスト
 
 ```bash
@@ -32,4 +26,8 @@ uv run mypy src
 
 ## Git 運用
 
-main ブランチのみで運用する。直接 push は不可、全ての変更は PR 経由で行う。
+main ブランチのみで運用する。develop ブランチは使用しない。
+
+- 作業ブランチ: `feature/{機能名}-#{Issue番号}` / `bugfix/{修正内容}-#{Issue番号}` を main から作成
+- PR の base: `main`
+- 直接 push は不可、全ての変更は PR 経由で行う


### PR DESCRIPTION
## Change type

- [x] docs

## Summary

- README.md から CLAUDE.md への循環参照（開発ガイドラインセクション）と利用先プロジェクト（関連セクション）を削除
- docs/overview.md を新規作成し、プロジェクト基盤情報（パッケージ構造・動作環境・テスト・Git運用）を集約
- CLAUDE.md の参照先を `@README.md` から `@docs/overview.md` に変更
- markdownlint-cli2 設定ファイルを追加（他プロジェクトと統一）

## Test plan

- [x] markdownlint-cli2 通過済み

## Related issues

Closes #9
Closes #10