### PR TITLE
feat(session-rotating-file-handler): SessionRotatingFileHandler を共通ライブラリに追加 (#20)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,6 +8,7 @@
 |-----------|------|
 | `py_common_lib.core` | HTTP 非依存のコアコンポーネント（BudgetTracker, CircuitBreaker） |
 | `py_common_lib.httpx` | httpx 用の制約付き HTTP クライアント（ConstrainedClient）とクランプユーティリティ |
+| `py_common_lib.logging` | セッション単位ローテーションファイルハンドラ（SessionRotatingFileHandler） |
 | `py_common_lib.secrets` | OS セキュアストレージからのシークレット取得（keyring） |
 
 ## 動作環境

--- a/docs/specs/infrastructure/constrained-client.md
+++ b/docs/specs/infrastructure/constrained-client.md
@@ -78,14 +78,14 @@ httpx.AsyncClient をラップし、全制約を統合する。async context man
 
 #### 初期化パラメータ
 
-| パラメータ | デフォルト | 説明 |
-|-----------|-----------|------|
-| `request_timeout` | 30.0 | 個別リクエストタイムアウト（秒）。許容範囲: 1〜120 |
-| `request_interval` | 1.0 | リクエスト間隔（秒）。許容範囲: 0.1〜60 |
-| `max_requests` | 10,000 | 操作あたりリクエスト上限。上限: 10,000 |
-| `circuit_breaker_threshold` | 5 | サーキットブレーカー閾値。上限: 5 |
-| `operation_timeout` | 600.0 | 操作全体タイムアウト（秒）。許容範囲: 1〜600 |
-| `headers` | None | HTTP ヘッダー |
+| パラメータ | 型 | デフォルト | 説明 |
+|-----------|---|----------|------|
+| `request_timeout` | `float` | 30.0 | 個別リクエストタイムアウト（秒）。許容範囲: 1〜120 |
+| `request_interval` | `float` | 1.0 | リクエスト間隔（秒）。許容範囲: 0.1〜60 |
+| `max_requests` | `int` | 10,000 | 操作あたりリクエスト上限。上限: 10,000 |
+| `circuit_breaker_threshold` | `int` | 5 | サーキットブレーカー閾値。上限: 5 |
+| `operation_timeout` | `float` | 600.0 | 操作全体タイムアウト（秒）。許容範囲: 1〜600 |
+| `headers` | `dict[str, str] \| None` | None | HTTP ヘッダー |
 
 | 操作 | 振る舞い |
 |------|---------|

--- a/docs/specs/infrastructure/session-rotating-file-handler.md
+++ b/docs/specs/infrastructure/session-rotating-file-handler.md
@@ -1,0 +1,95 @@
+# セッション単位ローテーションファイルハンドラ
+
+## 概要
+
+サイズ超過時に新ファイルへ切り替えるログファイルハンドラ。旧ファイルは削除せず保持する。
+
+スコープ:
+
+- セッション開始時刻と連番に基づくログファイル名の生成
+- サイズ閾値超過時のファイル切り替え（旧ファイル保持）
+- Python 標準 `logging.FileHandler` の拡張
+
+## 背景
+
+- Python 標準の `RotatingFileHandler` は `backupCount=0` でローテーション自体が無効化されるため、「サイズ超過で切り替えるが旧ファイルは消さない」という要件を満たせない
+- rag-knowledge で実装済みのカスタムハンドラを共通化し、複数プロジェクト（rag-knowledge, ai-assistant 等）から利用可能にする
+
+## 制約
+
+- ファイル名形式は `{prefix}YYYYMMDD-HHMMSS-NNNNN.log` で固定（NNNNN は 5 桁ゼロパディング連番）
+- 連番はセッション開始時に 00001 から始まる
+- `max_bytes` は正値必須（0 以下は `ValueError`）
+- 初期化時に対象ファイルが既に存在する場合は `FileExistsError` を送出する（既存ファイルの上書き防止）
+- ロールオーバー先ファイルが既に存在する場合も `FileExistsError` を送出する（`emit` 経由で `handleError` に委ねる）
+- `stream` が `None` の状態で `emit` された場合、追記モード（`mode='a'`）で再オープンする（既存内容の truncate 防止）
+
+## インターフェース
+
+### build_session_filename
+
+セッション開始時刻と連番からログファイル名を組み立てるユーティリティ関数。
+
+| 引数 | 型 | 説明 |
+|------|---|------|
+| `prefix` | `str` | ファイル名プレフィックス（例: `"app-server-"`） |
+| `started_at` | `datetime` | セッション開始時刻 |
+| `sequence` | `int` | 連番 |
+
+戻り値: `str` — `{prefix}YYYYMMDD-HHMMSS-NNNNN.log` 形式のファイル名
+
+### SessionRotatingFileHandler
+
+`logging.FileHandler` を継承したカスタムハンドラ。
+
+#### 初期化パラメータ
+
+| パラメータ | 型 | デフォルト | 説明 |
+|-----------|---|----------|------|
+| `log_dir` | `Path` | — | ログファイルの出力ディレクトリ |
+| `prefix` | `str` | — | ファイル名プレフィックス |
+| `started_at` | `datetime` | — | セッション開始時刻 |
+| `max_bytes` | `int` | — | ファイルサイズ閾値（バイト、正値必須）。超過で新ファイルへ切り替え |
+| `encoding` | `str` | `"utf-8"` | ファイルエンコーディング |
+
+#### 振る舞い
+
+| 操作 | 振る舞い |
+|------|---------|
+| 初期化 | `log_dir` に連番 00001 のファイルを作成モード（`mode='w'`）で開く。ファイルが既存の場合は `FileExistsError` |
+| emit | 書き込み前にファイルサイズを確認し、`max_bytes` 以上であれば新ファイルへ切り替えてから書き込む |
+| ロールオーバー | 現在のストリームを閉じ、連番をインクリメントして新ファイルを作成モード（`mode='w'`）で開く。切り替え先が既存の場合は `FileExistsError`（`handleError` に委ねる） |
+| stream 再オープン | `stream` が `None` の状態で `emit` された場合、追記モード（`mode='a'`）でファイルを再オープンする |
+
+#### サイズ判定
+
+`TextIOWrapper.tell()` はエンコーディング状態を含む不透明値のためサイズ判定に使用しない。`Path.stat().st_size` で実ファイルサイズを取得して判定する。
+
+## コンポーネント構成
+
+```mermaid
+flowchart TB
+    subgraph Logging["py_common_lib.logging"]
+        FN["build_session_filename()"]
+        SH["SessionRotatingFileHandler"]
+    end
+
+    SH -->|ファイル名生成| FN
+    SH -->|継承| FH["logging.FileHandler"]
+```
+
+- `logging/`: Python 標準 logging の拡張。`SessionRotatingFileHandler` と `build_session_filename` を提供
+
+## エッジケース
+
+| ケース | 振る舞い |
+|--------|---------|
+| 初期化時にファイルが既存 | `FileExistsError` を送出 |
+| ロールオーバー先ファイルが既存 | `FileExistsError` を `handleError` に委ねる |
+| `stream` が `None` で `emit` | 追記モードで再オープン（既存内容を保持） |
+| `max_bytes` が非常に小さい値 | 毎回ロールオーバーが発生するが正常動作する |
+
+## 関連ドキュメント
+
+- [rag-knowledge 仕様書](https://github.com/becky3/rag-knowledge/blob/main/docs/specs/rag-knowledge.md) — 移植元プロジェクト。ログファイル出力の仕様定義
+- [制約付き HTTP クライアント](constrained-client.md) — 同パッケージの既存仕様書

--- a/docs/specs/infrastructure/session-rotating-file-handler.md
+++ b/docs/specs/infrastructure/session-rotating-file-handler.md
@@ -20,6 +20,8 @@
 - ファイル名形式は `{prefix}YYYYMMDD-HHMMSS-NNNNN.log` で固定（NNNNN は 5 桁ゼロパディング連番）
 - 連番はセッション開始時に 00001 から始まる
 - `max_bytes` は正値必須（0 以下は `ValueError`）
+- `prefix` はパス区切り文字を含んではならない（`log_dir` 外への書き込み防止。違反時は `ValueError`）
+- ロールオーバー時の `baseFilename` は絶対パスで設定する（`log_dir` が相対パスの場合でも一貫した出力先を保証）
 - 初期化時に対象ファイルが既に存在する場合は `FileExistsError` を送出する（既存ファイルの上書き防止）
 - ロールオーバー先ファイルが既に存在する場合も `FileExistsError` を送出する（`emit` 経由で `handleError` に委ねる）
 - `stream` が `None` の状態で `emit` された場合、追記モード（`mode='a'`）で再オープンする（既存内容の truncate 防止）
@@ -88,6 +90,8 @@ flowchart TB
 | ロールオーバー先ファイルが既存 | `FileExistsError` を `handleError` に委ねる |
 | `stream` が `None` で `emit` | 追記モードで再オープン（既存内容を保持） |
 | `max_bytes` が非常に小さい値 | 毎回ロールオーバーが発生するが正常動作する |
+| `prefix` にパス区切り文字を含む | `ValueError` を送出 |
+| `log_dir` が相対パス | 初期化・ロールオーバーとも絶対パスで管理し一貫した出力先を保証 |
 
 ## 関連ドキュメント
 

--- a/src/py_common_lib/logging/__init__.py
+++ b/src/py_common_lib/logging/__init__.py
@@ -1,0 +1,11 @@
+"""セッション単位ローテーションファイルハンドラ."""
+
+from py_common_lib.logging.session_rotating_file_handler import (
+    SessionRotatingFileHandler,
+    build_session_filename,
+)
+
+__all__ = [
+    "SessionRotatingFileHandler",
+    "build_session_filename",
+]

--- a/src/py_common_lib/logging/session_rotating_file_handler.py
+++ b/src/py_common_lib/logging/session_rotating_file_handler.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -34,6 +35,9 @@ class SessionRotatingFileHandler(logging.FileHandler):
     ) -> None:
         if max_bytes <= 0:
             msg = f"max_bytes must be positive, got {max_bytes}"
+            raise ValueError(msg)
+        if Path(prefix).name != prefix:
+            msg = f"prefix must not contain path separators, got {prefix!r}"
             raise ValueError(msg)
         self._log_dir = log_dir
         self._prefix = prefix
@@ -77,6 +81,6 @@ class SessionRotatingFileHandler(logging.FileHandler):
             self.stream = None  # type: ignore[assignment]
         self._sequence += 1
         self._raise_if_current_exists()
-        self.baseFilename = str(self._current_path())
+        self.baseFilename = os.path.abspath(self._current_path())
         self.mode = "w"
         self.stream = self._open()

--- a/src/py_common_lib/logging/session_rotating_file_handler.py
+++ b/src/py_common_lib/logging/session_rotating_file_handler.py
@@ -1,0 +1,82 @@
+"""セッション単位で切り替わるログファイルハンドラ.
+
+仕様: docs/specs/infrastructure/session-rotating-file-handler.md
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+_SEQUENCE_WIDTH = 5
+
+
+def build_session_filename(prefix: str, started_at: datetime, sequence: int) -> str:
+    """セッション開始時刻と連番からログファイル名を組み立てる."""
+    timestamp = started_at.strftime("%Y%m%d-%H%M%S")
+    return f"{prefix}{timestamp}-{sequence:0{_SEQUENCE_WIDTH}d}.log"
+
+
+class SessionRotatingFileHandler(logging.FileHandler):
+    """サイズ超過時に新ファイルへ切り替える FileHandler.
+
+    仕様: docs/specs/infrastructure/session-rotating-file-handler.md
+    """
+
+    def __init__(
+        self,
+        log_dir: Path,
+        prefix: str,
+        started_at: datetime,
+        max_bytes: int,
+        encoding: str = "utf-8",
+    ) -> None:
+        if max_bytes <= 0:
+            msg = f"max_bytes must be positive, got {max_bytes}"
+            raise ValueError(msg)
+        self._log_dir = log_dir
+        self._prefix = prefix
+        self._started_at = started_at
+        self._max_bytes = max_bytes
+        self._sequence = 1
+        self._raise_if_current_exists()
+        super().__init__(self._current_path(), mode="w", encoding=encoding, delay=False)
+
+    def _current_path(self) -> Path:
+        return self._log_dir / build_session_filename(
+            self._prefix, self._started_at, self._sequence
+        )
+
+    def _raise_if_current_exists(self) -> None:
+        current = self._current_path()
+        if current.exists():
+            msg = f"Log file already exists: {current}"
+            raise FileExistsError(msg)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if self.stream is None:
+            self.mode = "a"
+            self.stream = self._open()
+        try:
+            if self._should_rollover():
+                self._do_rollover()
+        except Exception:
+            self.handleError(record)
+            return
+        super().emit(record)
+
+    def _should_rollover(self) -> bool:
+        if self.stream is None:
+            return False
+        return Path(self.baseFilename).stat().st_size >= self._max_bytes
+
+    def _do_rollover(self) -> None:
+        if self.stream is not None:
+            self.stream.close()
+            self.stream = None  # type: ignore[assignment]
+        self._sequence += 1
+        self._raise_if_current_exists()
+        self.baseFilename = str(self._current_path())
+        self.mode = "w"
+        self.stream = self._open()

--- a/tests/test_session_rotating_file_handler.py
+++ b/tests/test_session_rotating_file_handler.py
@@ -1,0 +1,159 @@
+"""セッション単位ログファイルハンドラのテスト.
+
+仕様: docs/specs/infrastructure/session-rotating-file-handler.md
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from py_common_lib.logging import (
+    SessionRotatingFileHandler,
+    build_session_filename,
+)
+
+_PREFIX = "app-server-"
+
+
+def _make_record(message: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+
+
+class TestBuildSessionFilename:
+    def test_format_uses_prefix_timestamp_and_zero_padded_sequence(self) -> None:
+        started_at = datetime(2026, 4, 17, 8, 30, 0)
+        assert (
+            build_session_filename(_PREFIX, started_at, 1) == "app-server-20260417-083000-00001.log"
+        )
+
+    def test_sequence_increments_preserve_five_digit_padding(self) -> None:
+        started_at = datetime(2026, 4, 17, 8, 30, 0)
+        assert (
+            build_session_filename(_PREFIX, started_at, 42)
+            == "app-server-20260417-083000-00042.log"
+        )
+
+    def test_different_prefix_produces_different_filename(self) -> None:
+        started_at = datetime(2026, 4, 17, 8, 30, 0)
+        assert (
+            build_session_filename("rag-server-", started_at, 1)
+            == "rag-server-20260417-083000-00001.log"
+        )
+
+
+class TestSessionRotatingFileHandler:
+    def test_initial_file_is_created_with_sequence_one(self, tmp_path: Path) -> None:
+        started_at = datetime(2026, 4, 17, 8, 30, 0)
+        handler = SessionRotatingFileHandler(
+            log_dir=tmp_path, prefix=_PREFIX, started_at=started_at, max_bytes=1_000_000
+        )
+        try:
+            handler.emit(_make_record("hello"))
+            handler.flush()
+        finally:
+            handler.close()
+        expected = tmp_path / "app-server-20260417-083000-00001.log"
+        assert expected.exists()
+        assert "hello" in expected.read_text(encoding="utf-8")
+
+    def test_rollover_opens_new_file_while_keeping_previous(self, tmp_path: Path) -> None:
+        started_at = datetime(2026, 4, 17, 8, 30, 0)
+        handler = SessionRotatingFileHandler(
+            log_dir=tmp_path, prefix=_PREFIX, started_at=started_at, max_bytes=50
+        )
+        try:
+            handler.emit(_make_record("seed-line" + "x" * 40))
+            for i in range(10):
+                handler.emit(_make_record(f"line-{i:02d}" + "x" * 40))
+            handler.flush()
+        finally:
+            handler.close()
+        first = tmp_path / "app-server-20260417-083000-00001.log"
+        second = tmp_path / "app-server-20260417-083000-00002.log"
+        assert first.exists()
+        assert second.exists()
+        first_content = first.read_text(encoding="utf-8")
+        assert "seed-line" in first_content
+        assert second.stat().st_size > 0
+
+    def test_existing_initial_file_raises_file_exists_error(self, tmp_path: Path) -> None:
+        started_at = datetime(2026, 4, 17, 8, 30, 0)
+        conflicting = tmp_path / "app-server-20260417-083000-00001.log"
+        conflicting.write_text("preexisting", encoding="utf-8")
+        with pytest.raises(FileExistsError):
+            SessionRotatingFileHandler(
+                log_dir=tmp_path,
+                prefix=_PREFIX,
+                started_at=started_at,
+                max_bytes=1_000_000,
+            )
+
+    @pytest.mark.parametrize("invalid_value", [0, -1])
+    def test_zero_or_negative_max_bytes_raises_value_error(
+        self, tmp_path: Path, invalid_value: int
+    ) -> None:
+        with pytest.raises(ValueError, match="max_bytes must be positive"):
+            SessionRotatingFileHandler(
+                log_dir=tmp_path,
+                prefix=_PREFIX,
+                started_at=datetime(2026, 4, 17, 8, 30, 0),
+                max_bytes=invalid_value,
+            )
+
+    def test_rollover_raises_when_next_file_already_exists(self, tmp_path: Path) -> None:
+        """ロールオーバー先ファイルが既存の場合、emit 経由で handleError に委ねる."""
+        started_at = datetime(2026, 4, 17, 8, 30, 0)
+        conflicting = tmp_path / "app-server-20260417-083000-00002.log"
+        conflicting.write_text("preexisting", encoding="utf-8")
+        handler = SessionRotatingFileHandler(
+            log_dir=tmp_path, prefix=_PREFIX, started_at=started_at, max_bytes=50
+        )
+        errors: list[BaseException] = []
+        handler.handleError = (  # type: ignore[method-assign]
+            lambda record: errors.append(  # noqa: ARG005
+                FileExistsError("rollover collision")
+            )
+        )
+        try:
+            for i in range(10):
+                handler.emit(_make_record(f"line-{i}" + "x" * 40))
+        finally:
+            handler.close()
+        assert errors, "handleError should capture rollover FileExistsError"
+        assert conflicting.read_text(encoding="utf-8") == "preexisting"
+
+    def test_emit_reopens_stream_in_append_mode(self, tmp_path: Path) -> None:
+        """stream=None 状態で emit されると mode='a' で再オープンされ既存内容を保持する."""
+        started_at = datetime(2026, 4, 17, 8, 30, 0)
+        handler = SessionRotatingFileHandler(
+            log_dir=tmp_path, prefix=_PREFIX, started_at=started_at, max_bytes=1_000_000
+        )
+        handler.emit(_make_record("first"))
+        handler.flush()
+        assert handler.stream is not None
+        handler.stream.close()
+        handler.stream = None  # type: ignore[assignment]
+
+        try:
+            handler.emit(_make_record("second"))
+            handler.flush()
+        finally:
+            handler.close()
+
+        assert handler.mode == "a"
+        log_path = tmp_path / "app-server-20260417-083000-00001.log"
+        content = log_path.read_text(encoding="utf-8")
+        assert "first" in content
+        assert "second" in content

--- a/tests/test_session_rotating_file_handler.py
+++ b/tests/test_session_rotating_file_handler.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -112,6 +113,18 @@ class TestSessionRotatingFileHandler:
                 max_bytes=invalid_value,
             )
 
+    @pytest.mark.parametrize("bad_prefix", ["../evil-", "sub/dir-", "back\\slash-"])
+    def test_prefix_with_path_separators_raises_value_error(
+        self, tmp_path: Path, bad_prefix: str
+    ) -> None:
+        with pytest.raises(ValueError, match="prefix must not contain path separators"):
+            SessionRotatingFileHandler(
+                log_dir=tmp_path,
+                prefix=bad_prefix,
+                started_at=datetime(2026, 4, 17, 8, 30, 0),
+                max_bytes=1_000_000,
+            )
+
     def test_rollover_raises_when_next_file_already_exists(self, tmp_path: Path) -> None:
         """ロールオーバー先ファイルが既存の場合、emit 経由で handleError に委ねる."""
         started_at = datetime(2026, 4, 17, 8, 30, 0)
@@ -120,18 +133,24 @@ class TestSessionRotatingFileHandler:
         handler = SessionRotatingFileHandler(
             log_dir=tmp_path, prefix=_PREFIX, started_at=started_at, max_bytes=50
         )
-        errors: list[BaseException] = []
-        handler.handleError = (  # type: ignore[method-assign]
-            lambda record: errors.append(  # noqa: ARG005
-                FileExistsError("rollover collision")
-            )
-        )
+        captured_exceptions: list[BaseException] = []
+
+        original_handle_error = handler.handleError
+
+        def capturing_handle_error(record: logging.LogRecord) -> None:
+            exc = sys.exc_info()[1]
+            if exc is not None:
+                captured_exceptions.append(exc)
+            original_handle_error(record)
+
+        handler.handleError = capturing_handle_error  # type: ignore[method-assign]
         try:
             for i in range(10):
                 handler.emit(_make_record(f"line-{i}" + "x" * 40))
         finally:
             handler.close()
-        assert errors, "handleError should capture rollover FileExistsError"
+        assert captured_exceptions, "handleError should capture rollover exception"
+        assert isinstance(captured_exceptions[0], FileExistsError)
         assert conflicting.read_text(encoding="utf-8") == "preexisting"
 
     def test_emit_reopens_stream_in_append_mode(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Change type

- [x] feat（新機能）

## Summary

- rag-knowledge から `SessionRotatingFileHandler` を移植し、`py_common_lib.logging` パッケージとして共通化
- ファイル名プレフィックスをコンストラクタ引数 `prefix` としてパラメータ化（移植元は `rag-server-` 固定）
- `max_bytes` の正値バリデーション追加、ロールオーバー時の `mode='w'` 明示（レビュー指摘対応）
- constrained-client.md の初期化パラメータテーブルに型列を追加（同カテゴリ仕様書の列構成統一）

## Test plan

- [x] pytest 73テスト全通過（新規10テスト含む）
- [x] ruff check / ruff format / mypy 全パス

## Related issues

Closes #20

rag-knowledge の import 切り替え: becky3/rag-knowledge#637