### PR TITLE
fix(session-rotating-file-handler): prefix バリデ��ションの Linux 対応と CI 移行 (#24, #25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,24 @@
-name: CI
+# Quality Check — Caller
+#
+# PR 作成・更新時の品質チェック（テスト・lint・型チェック・markdownlint）。
+# Reusable Workflow (shared-workflows) を呼び出す。
 
-on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+name: Quality Check
 
 permissions:
   contents: read
 
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-      - run: uv sync
-      - run: uv run ruff check .
-      - run: uv run ruff format --check .
-      - run: uv run mypy src
+on:
+  pull_request:
+    branches: [main]
 
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-      - run: uv sync
-      - run: uv run pytest --tb=short
+jobs:
+  quality:
+    uses: becky3/shared-workflows/.github/workflows/quality-check.yml@main
+    with:
+      python_version: "3.11"
+      install_command: "uv sync"
+      test_command: "uv run pytest --tb=short"
+      lint_command: "uv run ruff check . && uv run ruff format --check ."
+      typecheck_command: "uv run mypy src"
+      markdownlint: true

--- a/src/py_common_lib/logging/session_rotating_file_handler.py
+++ b/src/py_common_lib/logging/session_rotating_file_handler.py
@@ -36,7 +36,7 @@ class SessionRotatingFileHandler(logging.FileHandler):
         if max_bytes <= 0:
             msg = f"max_bytes must be positive, got {max_bytes}"
             raise ValueError(msg)
-        if Path(prefix).name != prefix:
+        if "/" in prefix or "\\" in prefix:
             msg = f"prefix must not contain path separators, got {prefix!r}"
             raise ValueError(msg)
         self._log_dir = log_dir


### PR DESCRIPTION
## Change type

- [x] fix — バグ修正
- [x] ci — CI/CD 変更

## Summary

- prefix バリデーションを `Path(prefix).name != prefix`（OS依存）から `"/" in prefix or "\\" in prefix`（プラットフォーム非依存）に変更
- CI ワ��クフローを shared-workflows の quality-check.yml caller に移行（markdownlint 追加）
- main ブランチに branch protection（必須ステータスチェック）を設定済み

## Test plan

- [x] pytest 76 tests 全通���
- [x] ruff check / ruff format 通過
- [x] mypy 通過
- [ ] Linux CI でテスト全通過を確認

## Related issues

Closes #24
Closes #25